### PR TITLE
fixed galaxy resizing to take the navbar into account

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -46,17 +46,18 @@ function animate(){
 function scaleGalaxyToScreen(){
   const galaxyWidth = 2900
   const galaxyHeight = 1500
+  const navbarHeight = 92
   const windowWidth = window.innerWidth
-  const windowHeight = window.innerHeight
+  const windowHeight = window.innerHeight - navbarHeight
   
   const widthRatio = windowWidth/galaxyWidth
   const heightRatio = windowHeight/galaxyHeight
   
   if(widthRatio>heightRatio){
-    $('.scale').css('transform', 'scale(' + heightRatio + ')');
+    $('.scale').css('transform', 'scale(' + heightRatio + ') translateY( '+ navbarHeight +'px)');
     galaxyScale=heightRatio;
   }else{
-    $('.scale').css('transform', 'scale(' + widthRatio + ')');
+    $('.scale').css('transform', 'scale(' + widthRatio + ') translateY( '+ navbarHeight +'px)');
     galaxyScale=widthRatio;
   }
 }


### PR DESCRIPTION
the resizing function will now take the navbar height into account when resizing the galaxy. 
the galaxy is also offset down, centering the galaxy between the bottom of the navbar and the bottom of the page (instead of simply the center of the page)

## Summary by Sourcery

Bug Fixes:
- Subtract the navbar height from the available window height when calculating the galaxy scale and apply a translateY offset by the navbar height to center the galaxy below it